### PR TITLE
bump to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-store-router",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Sync between the current router URL and @ngrx/store",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
avoid conflict depencies with angular 2 beta 17

stack error: 

```
npm ERR! peerinvalid The package rxjs@5.0.0-beta.2 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer @ngrx/store@1.4.0 wants rxjs@5.0.0-beta.6
npm ERR! peerinvalid Peer angular2@2.0.0-beta.17 wants rxjs@5.0.0-beta.6
npm ERR! peerinvalid Peer ngrx-store-router@0.0.7 wants rxjs@^5.0.0-beta.2
```
